### PR TITLE
Add 'Difference of Squares' exercise in F#

### DIFF
--- a/difference-of-squares/DifferenceOfSquares.fs
+++ b/difference-of-squares/DifferenceOfSquares.fs
@@ -1,0 +1,10 @@
+module DifferenceOfSquares
+
+let squareOfSum (number: int): int =
+    pown (number * (number + 1) / 2) 2
+
+let sumOfSquares (number: int): int =
+    number * (number + 1) * (2 * number + 1) / 6
+
+let differenceOfSquares (number: int): int =
+    squareOfSum number - sumOfSquares number

--- a/difference-of-squares/DifferenceOfSquares.fsproj
+++ b/difference-of-squares/DifferenceOfSquares.fsproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="DifferenceOfSquares.fs" />
+    <Compile Include="DifferenceOfSquaresTests.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="FsUnit.xUnit" Version="4.0.4" />
+  </ItemGroup>
+
+</Project>

--- a/difference-of-squares/DifferenceOfSquares.sln
+++ b/difference-of-squares/DifferenceOfSquares.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 25.0.1706.11
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "DifferenceOfSquares", "DifferenceOfSquares.fsproj", "{CF3D734D-9E29-45C8-9912-A3929EBC2BE5}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CF3D734D-9E29-45C8-9912-A3929EBC2BE5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CF3D734D-9E29-45C8-9912-A3929EBC2BE5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CF3D734D-9E29-45C8-9912-A3929EBC2BE5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CF3D734D-9E29-45C8-9912-A3929EBC2BE5}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {16583B62-46ED-4C03-8C9F-84E1E63EF677}
+	EndGlobalSection
+EndGlobal

--- a/difference-of-squares/DifferenceOfSquaresTests.fs
+++ b/difference-of-squares/DifferenceOfSquaresTests.fs
@@ -1,0 +1,43 @@
+module DifferenceOfSquaresTests
+
+open FsUnit.Xunit
+open Xunit
+
+open DifferenceOfSquares
+
+[<Fact>]
+let ``Square of sum 1`` () =
+    squareOfSum 1 |> should equal 1
+
+[<Fact>]
+let ``Square of sum 5`` () =
+    squareOfSum 5 |> should equal 225
+
+[<Fact>]
+let ``Square of sum 100`` () =
+    squareOfSum 100 |> should equal 25502500
+
+[<Fact>]
+let ``Sum of squares 1`` () =
+    sumOfSquares 1 |> should equal 1
+
+[<Fact>]
+let ``Sum of squares 5`` () =
+    sumOfSquares 5 |> should equal 55
+
+[<Fact>]
+let ``Sum of squares 100`` () =
+    sumOfSquares 100 |> should equal 338350
+
+[<Fact>]
+let ``Difference of squares 1`` () =
+    differenceOfSquares 1 |> should equal 0
+
+[<Fact>]
+let ``Difference of squares 5`` () =
+    differenceOfSquares 5 |> should equal 170
+
+[<Fact>]
+let ``Difference of squares 100`` () =
+    differenceOfSquares 100 |> should equal 25164150
+

--- a/difference-of-squares/README.md
+++ b/difference-of-squares/README.md
@@ -1,0 +1,43 @@
+# Difference of Squares
+
+Welcome to Difference of Squares on Exercism's F# Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+Find the difference between the square of the sum and the sum of the squares of the first N natural numbers.
+
+The square of the sum of the first ten natural numbers is
+(1 + 2 + ... + 10)² = 55² = 3025.
+
+The sum of the squares of the first ten natural numbers is
+1² + 2² + ... + 10² = 385.
+
+Hence the difference between the square of the sum of the first ten natural numbers and the sum of the squares of the first ten natural numbers is 3025 - 385 = 2640.
+
+You are not expected to discover an efficient solution to this yourself from first principles; research is allowed, indeed, encouraged.
+Finding the best algorithm for the problem is a key skill in software engineering.
+
+For this exercise the following F# features come in handy:
+- [(..) start finish](https://fsharp.github.io/fsharp-core-docs/reference/fsharp-core-operators.html#(..)) allows you to succinctly create a range of values.
+- [List.sumBy](https://fsharp.github.io/fsharp-core-docs/reference/fsharp-collections-listmodule.html#sumBy) is a condensed format to apply a function to a list and then sum the results.
+
+## Source
+
+### Created by
+
+- @jwood803
+
+### Contributed to by
+
+- @ErikSchierboom
+- @jrr
+- @kytrinyx
+- @lestephane
+- @robkeim
+- @valentin-p
+- @wolf99
+
+### Based on
+
+Problem 6 at Project Euler - https://projecteuler.net/problem=6


### PR DESCRIPTION
This commit introduces a new exercise called 'Difference of Squares'. It includes the instructions in the README.md file, the implementation in DifferenceOfSquares.fs, and the corresponding tests in DifferenceOfSquaresTests.fs. It also adds a new solution file and updates the project file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced mathematical functions to calculate the square of the sum, the sum of squares, and their difference for a range of numbers.
- **Tests**
	- Added test cases to ensure accuracy of the new mathematical functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->