### PR TITLE
Add 'Two Fer' exercise files and tests

### DIFF
--- a/two-fer/README.md
+++ b/two-fer/README.md
@@ -1,0 +1,56 @@
+# Two Fer
+
+Welcome to Two Fer on Exercism's F# Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Introduction
+
+In some English accents, when you say "two for" quickly, it sounds like "two fer".
+Two-for-one is a way of saying that if you buy one, you also get one for free.
+So the phrase "two-fer" often implies a two-for-one offer.
+
+Imagine a bakery that has a holiday offer where you can buy two cookies for the price of one ("two-fer one!").
+You take the offer and (very generously) decide to give the extra cookie to someone else in the queue.
+
+## Instructions
+
+Your task is to determine what you will say as you give away the extra cookie.
+
+If you know the person's name (e.g. if they're named Do-yun), then you will say:
+
+```text
+One for Do-yun, one for me.
+```
+
+If you don't know the person's name, you will say _you_ instead.
+
+```text
+One for you, one for me.
+```
+
+Here are some examples:
+
+| Name   | Dialogue                    |
+| :----- | :-------------------------- |
+| Alice  | One for Alice, one for me.  |
+| Bohdan | One for Bohdan, one for me. |
+|        | One for you, one for me.    |
+| Zaphod | One for Zaphod, one for me. |
+
+## Source
+
+### Created by
+
+- @robkeim
+
+### Contributed to by
+
+- @ErikSchierboom
+- @jrr
+- @lestephane
+- @valentin-p
+- @wolf99
+
+### Based on
+
+https://github.com/exercism/problem-specifications/issues/757

--- a/two-fer/TwoFer.fs
+++ b/two-fer/TwoFer.fs
@@ -1,0 +1,6 @@
+module TwoFer
+
+let twoFer (input: string option): string =
+    let name = Option.defaultValue "you" input
+    $"One for {name}, one for me."
+    

--- a/two-fer/TwoFer.fsproj
+++ b/two-fer/TwoFer.fsproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="TwoFer.fs" />
+    <Compile Include="TwoFerTests.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="FsUnit.xUnit" Version="4.0.4" />
+  </ItemGroup>
+
+</Project>

--- a/two-fer/TwoFerTests.fs
+++ b/two-fer/TwoFerTests.fs
@@ -1,0 +1,19 @@
+module TwoFerTests
+
+open FsUnit.Xunit
+open Xunit
+
+open TwoFer
+
+[<Fact>]
+let ``No name given`` () =
+    twoFer None |> should equal "One for you, one for me."
+
+[<Fact>]
+let ``A name given`` () =
+    twoFer (Some "Alice") |> should equal "One for Alice, one for me."
+
+[<Fact>]
+let ``Another name given`` () =
+    twoFer (Some "Bob") |> should equal "One for Bob, one for me."
+


### PR DESCRIPTION
In this commit, new files 'README.md', 'TwoFer.fs', 'TwoFerTests.fs', and 'TwoFer.fsproj' have been created. These files contain the instructions, the function to implement, tests cases and project configurations respectively for the "Two Fer" exercise on Exercism's F# track.

@coderabbitai ignore