### PR TITLE
Add NBA teams history exploration functionality

### DIFF
--- a/bandwagoner/Bandwagoner.fs
+++ b/bandwagoner/Bandwagoner.fs
@@ -1,0 +1,32 @@
+module Bandwagoner
+
+type Coach = { Name: string; FormerPlayer: bool }
+
+type Stats = { Wins: int; Losses: int }
+
+type Team =
+    { Name: string
+      Coach: Coach
+      Stats: Stats }
+
+let createCoach (name: string) (formerPlayer: bool) : Coach =
+    { Name = name
+      FormerPlayer = formerPlayer }
+
+let createStats (wins: int) (losses: int) : Stats = { Wins = wins; Losses = losses }
+
+let createTeam (name: string) (coach: Coach) (stats: Stats) : Team =
+    { Name = name
+      Coach = coach
+      Stats = stats }
+
+let replaceCoach (team: Team) (coach: Coach) : Team = { team with Coach = coach }
+
+let isSameTeam (homeTeam: Team) (awayTeam: Team) : bool = homeTeam = awayTeam
+
+let rootForTeam (team: Team) : bool =
+    team.Coach.Name = "Gregg Popovich"
+    || team.Coach.FormerPlayer
+    || team.Name = "Chicago Bulls"
+    || team.Stats.Wins >= 60
+    || team.Stats.Losses > team.Stats.Wins

--- a/bandwagoner/Bandwagoner.fsproj
+++ b/bandwagoner/Bandwagoner.fsproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Bandwagoner.fs" />
+    <Compile Include="BandwagonerTests.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="FsUnit.xUnit" Version="4.0.4" />
+    <PackageReference Include="Exercism.Tests" Version="0.1.0-beta1" />
+  </ItemGroup>
+
+</Project>

--- a/bandwagoner/BandwagonerTests.fs
+++ b/bandwagoner/BandwagonerTests.fs
@@ -1,0 +1,281 @@
+module BandwagonerTests
+
+open FsUnit.Xunit
+open Xunit
+open Exercism.Tests
+
+open Bandwagoner
+
+[<Fact>]
+[<Task(2)>]
+let ``Create coach that was a former player`` () =
+    createCoach "Steve Kerr" true
+    |> should equal
+           { Name = "Steve Kerr"
+             FormerPlayer = true }
+
+[<Fact>]
+[<Task(2)>]
+let ``Create coach that wasn't a former player`` () =
+    createCoach "Erik Spoelstra" false
+    |> should equal
+           { Name = "Erik Spoelstra"
+             FormerPlayer = false }
+
+[<Fact>]
+[<Task(3)>]
+let ``Create stats for winning team`` () =
+    createStats 55 27
+    |> should equal { Wins = 55; Losses = 27 }
+
+[<Fact>]
+[<Task(3)>]
+let ``Create stats for losing team`` () =
+    createStats 39 43
+    |> should equal { Wins = 39; Losses = 43 }
+
+[<Fact>]
+[<Task(3)>]
+let ``Create stats for all-time season record`` () =
+    createStats 73 9
+    |> should equal { Wins = 73; Losses = 9 }
+
+[<Fact>]
+[<Task(4)>]
+let ``Create 60's team`` () =
+    let coach = createCoach "Red Auerbach" false
+    let stats = createStats 58 22
+    let team = createTeam "Boston Celtics" coach stats
+
+    team
+    |> should equal
+           { Name = "Boston Celtics"
+             Coach =
+                 { Name = "Red Auerbach"
+                   FormerPlayer = false }
+             Stats = { Wins = 58; Losses = 22 } }
+
+[<Fact>]
+[<Task(4)>]
+let ``Create 2010's team`` () =
+    let coach = createCoach "Rick Carlisle" false
+    let stats = createStats 57 25
+
+    let team =
+        createTeam "Dallas Mavericks" coach stats
+
+    team
+    |> should equal
+           { Name = "Dallas Mavericks"
+             Coach =
+                 { Name = "Rick Carlisle"
+                   FormerPlayer = false }
+             Stats = { Wins = 57; Losses = 25 } }
+
+[<Fact>]
+[<Task(5)>]
+let ``Replace coach mid-season`` () =
+    let oldCoach = createCoach "Willis Reed" true
+    let newCoach = createCoach "Red Holzman" true
+    let stats = createStats 6 8
+
+    let team =
+        createTeam "New York Knicks" oldCoach stats
+
+    replaceCoach team newCoach
+    |> should equal
+           { Name = "New York Knicks"
+             Coach =
+                 { Name = "Red Holzman"
+                   FormerPlayer = true }
+             Stats = { Wins = 6; Losses = 8 } }
+
+[<Fact>]
+[<Task(5)>]
+let ``Replace coach after season`` () =
+    let oldCoach = createCoach "Rudy Tomjanovich" true
+    let newCoach = createCoach "Jeff van Gundy" true
+    let stats = createStats 43 39
+
+    let team =
+        createTeam "Houston Rockets" oldCoach stats
+
+    replaceCoach team newCoach
+    |> should equal
+           { Name = "Houston Rockets"
+             Coach =
+                 { Name = "Jeff van Gundy"
+                   FormerPlayer = true }
+             Stats = { Wins = 43; Losses = 39 } }
+
+[<Fact>]
+[<Task(6)>]
+let ``Same team is duplicate`` () =
+    let coach = createCoach "Pat Riley" true
+    let stats = createStats 57 25
+    let team = createTeam "Los Angeles Lakers" coach stats
+
+    isSameTeam team team
+    |> should equal true
+
+[<Fact>]
+[<Task(6)>]
+let ``Same team with different stats is not a duplicate`` () =
+    let coach = createCoach "Pat Riley" true
+    let stats = createStats 57 25
+    let team = createTeam "Los Angeles Lakers" coach stats
+    
+    let newStats = createStats 62 20
+    let teamWithDifferentStats = createTeam "Los Angeles Lakers" coach newStats
+
+    isSameTeam team teamWithDifferentStats
+    |> should equal false
+
+[<Fact>]
+[<Task(6)>]
+let ``Same team with different coach is not a duplicate`` () =
+    let coach = createCoach "Pat Riley" true    
+    let stats = createStats 33 39    
+    let team = createTeam "Los Angeles Lakers" coach stats
+    
+    let newCoach = createCoach "John Kundla" true
+    let teamWithDifferentCoach = createTeam "Los Angeles Lakers" newCoach stats
+
+    isSameTeam team teamWithDifferentCoach
+    |> should equal false
+
+[<Fact>]
+[<Task(6)>]
+let ``Different team with same coach and stats`` () =
+    let stats = createStats 0 0
+    let coach = createCoach "Mike d'Antoni" true
+    
+    let team = createTeam "Denver Nuggets" coach stats
+    let otherTeam = createTeam "Phoenix Suns" coach stats
+
+    isSameTeam team otherTeam
+    |> should equal false
+
+[<Fact>]
+[<Task(6)>]
+let ``Different team with different coach and stats`` () =
+    let stats = createStats 42 40
+    let coach = createCoach "Dave Joerger" true    
+    let team = createTeam "Memphis Grizzlies" coach stats
+    
+    let otherStats = createStats 63 19
+    let otherCoach = createCoach "Larry Costello" true
+    let otherTeam = createTeam "Milwaukee Bucks" otherCoach otherStats
+
+    isSameTeam team otherTeam
+    |> should equal false
+
+[<Fact>]
+[<Task(7)>]
+let ``Root for team with favorite coach and winning stats`` () =
+    let stats = createStats 60 22
+    let coach = createCoach "Gregg Popovich" false    
+    let team = createTeam "San Antonio Spurs" coach stats
+
+    rootForTeam team
+    |> should equal true    
+
+[<Fact>]
+[<Task(7)>]
+let ``Root for team with favorite coach and losing stats`` () =
+    let stats = createStats 17 47
+    let coach = createCoach "Gregg Popovich" false    
+    let team = createTeam "San Antonio Spurs" coach stats
+
+    rootForTeam team
+    |> should equal true    
+
+[<Fact>]
+[<Task(7)>]
+let ``Root for team with coach is former player and winning stats`` () =
+    let stats = createStats 49 33
+    let coach = createCoach "Jack Ramsay" true    
+    let team = createTeam "Portland Trail Blazers" coach stats
+
+    rootForTeam team
+    |> should equal true    
+
+[<Fact>]
+[<Task(7)>]
+let ``Root for team with coach is former player and losing stats`` () =
+    let stats = createStats 0 7
+    let coach = createCoach "Jack Ramsay" true    
+    let team = createTeam "Indiana Pacers" coach stats
+
+    rootForTeam team
+    |> should equal true  
+
+[<Fact>]
+[<Task(7)>]
+let ``Root for favorite team and winning stats`` () =
+    let stats = createStats 61 21
+    let coach = createCoach "Phil Jackson" true    
+    let team = createTeam "Chicago Bulls" coach stats
+
+    rootForTeam team
+    |> should equal true
+
+[<Fact>]
+[<Task(7)>]
+let ``Root for favorite team and losing stats`` () =
+    let stats = createStats 24 58
+    let coach = createCoach "Dick Motta" false    
+    let team = createTeam "Chicago Bulls" coach stats
+
+    rootForTeam team
+    |> should equal true
+
+[<Fact>]
+[<Task(7)>]
+let ``Root for team with sixty or more wins and former player coach`` () =
+    let stats = createStats 65 17
+    let coach = createCoach "Billy Cunningham" true    
+    let team = createTeam "Philadelphia 76'ers" coach stats
+
+    rootForTeam team
+    |> should equal true
+
+[<Fact>]
+[<Task(7)>]
+let ``Root for team with sixty or more wins and non former player coach`` () =
+    let stats = createStats 60 22
+    let coach = createCoach "Mike Budenholzer" false    
+    let team = createTeam "Milwaukee Bucks" coach stats
+
+    rootForTeam team
+    |> should equal true
+
+[<Fact>]
+[<Task(7)>]
+let ``Root for team with more losses than wins and former player coach`` () =
+    let stats = createStats 40 42
+    let coach = createCoach "Wes Unseld" true    
+    let team = createTeam "Washington Bullets" coach stats
+
+    rootForTeam team
+    |> should equal true
+
+[<Fact>]
+[<Task(7)>]
+let ``Root for team with more losses than wins and non former player coach`` () =
+    let stats = createStats 29 43
+    let coach = createCoach "Kenny Atkinson" false    
+    let team = createTeam "Rochester Royals" coach stats
+
+    rootForTeam team
+    |> should equal true
+
+[<Fact>]
+[<Task(7)>]
+let ``Don't root for team not matching criteria`` () =
+    let stats = createStats 51 31
+    let coach = createCoach "Frank Layden" false    
+    let team = createTeam "Utah Jazz" coach stats
+
+    rootForTeam team
+    |> should equal false

--- a/bandwagoner/README.md
+++ b/bandwagoner/README.md
@@ -1,0 +1,172 @@
+# Bandwagoner
+
+Welcome to Bandwagoner on Exercism's F# Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+If you get stuck on the exercise, check out `HINTS.md`, but try and solve it without using those first :)
+
+## Introduction
+
+## Records
+
+A record is a collection of fields (which can be of different types) that belong together. To define a record the `type` keyword is used. A record's fields are defined between `{` and `}` characters, and each field has a name _and_ a type. To create a record, specify the names of the fields and assign a value to them between `{` and `}` characters. All fields must be assigned a value when creating a record. A record instance's field values can be accessed using dot-notation.
+
+When defining/creating a record, each field must either be on a separate line or separated by semicolons (`;`) when on a single line.
+
+```fsharp
+// Define a record
+type Address =
+    { Street: string
+      HouseNumber: int }
+
+// Create a record
+let oldAddress: Address =
+    { Street = "Main Street"
+      HouseNumber = 17 }
+
+// Single-line alternative
+type ConciseAddress = { Street: string; HouseNumber: int }
+let conciseAddress: ConciseAddress = { Street = "Main Street"; HouseNumber = 17 }
+```
+
+As records are immutable, once a record has been constructed, its field values can never change. If you'd like to change a record's values, the `with` keyword allows you to create a copy of an existing record, but with new values for one or more fields.
+
+```fsharp
+// Copy the old address but change the house number
+let newAddress: Address = { oldAddress with HouseNumber = 86 }
+newAddress.Street      // => "Main Street"
+newAddress.HouseNumber // => 86
+```
+
+Records have _structural equality_, which means that two instances of the same record with identical values are equivalent.
+
+Besides being able to use dot-notation to access a record's fields, records can also be _deconstructed_ in bindings and in pattern matching:
+
+```fsharp
+let myAddress: Address = { Street = "Broadway"; HouseNumber = 123 }
+let { Street = myStreet; HouseNumber = myHouseNumber } = myAddress
+
+match myAddress with
+| { HouseNumber = 1 } -> printfn "First house"
+| { HouseNumber = houseNumber; Street = street } -> printfn "House number %d on %s" houseNumber street
+// => "House number 123 on Broadway
+```
+
+## Instructions
+
+In this exercise you're a big sports fan and you've just discovered a passion for NBA basketball. Being new to NBA basketball, you're doing a deep dive into NBA history, keeping track of teams, coaches, their win/loss stats and comparing them against each other.
+
+As you don't yet have a favorite team, you'll also be developing an algorithm to figure out whether to root for a particular team.
+
+You have seven tasks to help you develop your proprietary _root-for-a-team_ algorithm.
+
+## 1. Define the model
+
+Define the `Coach` record with the following two fields:
+
+- `Name`: the coach's name, of type `string`.
+- `FormerPlayer`: indicates if the coach was a former player, of type `bool`.
+
+Define the `Stats` record with the following two fields:
+
+- `Wins`: the number of wins, of type `int`.
+- `Losses`: the number of losses, of type `int`.
+
+Define the `Team` record with the following three fields:
+
+- `Name`: the team's name, of type `string`.
+- `Coach`: the team's coach, of type `Coach`.
+- `Stats`: the team's stats, of type `Stats`.
+
+## 2. Create a team's coach
+
+Implement the `createCoach` function that takes the coach name and its former player status as parameters, and returns its `Coach` record:
+
+```fsharp
+createCoach "Larry Bird" true
+// => { Name = "Larry Bird"; FormerPlayer = true }
+```
+
+## 3. Create a team's stats
+
+Implement the `createStats` function that takes the number of wins and the number losses as parameters, and returns its `Stats` record:
+
+```fsharp
+createStats 58 24
+// => { Wins = 58; Losses = 24 }
+```
+
+## 4. Create a team
+
+Implement the `createTeam` function that takes the team name, coach and record as parameters, and returns its `Team` record:
+
+```fsharp
+let coach = createCoach "Larry Bird" true
+let record = createStats 58 24
+createTeam "Indiana Pacers" coach record
+// => { Name = "Indiana Pacers"
+//      Coach = { Name = "Larry Bird"; FormerPlayer = true }
+//      Stats = { Wins = 58; Losses = 24 } }
+```
+
+## 5. Replace the coach
+
+NBA owners being impatient, you found that bad team results would often lead to the coach being replaced. Implement the `replaceCoach` function that takes the team and its new coach as parameters, and returns the team but with the new coach:
+
+```fsharp
+let coach = createCoach "Larry Bird" true
+let record = createStats 58 24
+let team = createTeam "Indiana Pacers" coach record
+
+let newCoach = createCoach "Isiah Thomas" true
+replaceCoach team newCoach
+// => { Name = "Indiana Pacers"
+//      Coach = { Name = "Isiah Thomas"; FormerPlayer = true }
+//      Stats = { Wins = 58; Losses = 24 } }
+```
+
+## 6. Check for same team
+
+While digging into stats, you're keeping lists of teams and their records. Sometimes, you get things wrong and there are duplicate entries on your list. Implement the `isSameTeam` function that takes two teams and returns `true` if they are the same team; otherwise, return `false`:
+
+```fsharp
+let pacersCoach = createCoach "Larry Bird" true
+let pacersStats = createStats 58 24
+let pacersTeam = createTeam "Indiana Pacers" pacersCoach pacersStats
+
+let lakersCoach = createCoach "Del Harris" false
+let lakersStats = createStats 61 21
+let lakersTeam = createTeam "LA Lakers" lakersCoach lakersStats
+
+isSameTeam pacersTeam lakersTeam
+// => false
+```
+
+## 7. Check if you should root for a team
+
+Having looked at many teams and matches, you've come up with an algorithm. If one of the following is true, you root for that team:
+
+- The coach's name is "Gregg Popovich"
+- The coach is a former player
+- The team's name is the "Chicago Bulls"
+- The team has won 60 or more games
+- The team has more losses than wins
+
+Implement the `rootForTeam` function that takes a team and returns `true` if you should root for that team; otherwise, `return` false:
+
+```fsharp
+let spursCoach = createCoach "Gregg Popovich" false
+let spursStats = createStats 56 26
+let spursTeam = createTeam "San Antonio Spurs" spursCoach spursStats
+rootForTeam spursTeam
+// => true
+```
+
+## Source
+
+### Created by
+
+- @ErikSchierboom
+
+### Contributed to by
+
+- @valentin-p


### PR DESCRIPTION
This commit adds the functionality for exploring the history of NBA teams, focusing on coaches and win/loss stats. It includes a method for determining if a specific coach should be replaced and whether a fan should root for a specific team based on various conditions, such as the coach's name and past player status, the team's name, and their win/loss stats.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new types and functions in the Bandwagoner module to manage coaches, stats, and teams more effectively.
  - Added a feature to determine if a team is worth rooting for based on specific criteria.

- **Enhancements**
  - Enhanced the `Coach` type to include a field indicating if they were a former player.
  - Enhanced the `Team` type to include detailed information about the coach and team statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->