### PR TITLE
Add Raindrops exercise with tests

### DIFF
--- a/raindrops/README.md
+++ b/raindrops/README.md
@@ -1,0 +1,53 @@
+# Raindrops
+
+Welcome to Raindrops on Exercism's F# Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Introduction
+
+Raindrops is a slightly more complex version of the FizzBuzz challenge, a classic interview question.
+
+## Instructions
+
+Your task is to convert a number into its corresponding raindrop sounds.
+
+If a given number:
+
+- is divisible by 3, add "Pling" to the result.
+- is divisible by 5, add "Plang" to the result.
+- is divisible by 7, add "Plong" to the result.
+- **is not** divisible by 3, 5, or 7, the result should be the number as a string.
+
+## Examples
+
+- 28 is divisible by 7, but not 3 or 5, so the result would be `"Plong"`.
+- 30 is divisible by 3 and 5, but not 7, so the result would be `"PlingPlang"`.
+- 34 is not divisible by 3, 5, or 7, so the result would be `"34"`.
+
+~~~~exercism/note
+A common way to test if one number is evenly divisible by another is to compare the [remainder][remainder] or [modulus][modulo] to zero.
+Most languages provide operators or functions for one (or both) of these.
+
+[remainder]: https://exercism.org/docs/programming/operators/remainder
+[modulo]: https://en.wikipedia.org/wiki/Modulo_operation
+~~~~
+
+- Think of this in a generic way. If you're familiar with the (fizz buzz)[https://en.wikipedia.org/wiki/Fizz_buzz] problem this is similar except there are three conditions instead of two. How would you implement this knowing that one day we might want to extend to four, five, or even ten types of raindrops?
+
+## Source
+
+### Created by
+
+- @ErikSchierboom
+
+### Contributed to by
+
+- @jrr
+- @lestephane
+- @robkeim
+- @valentin-p
+- @wolf99
+
+### Based on
+
+A variation on FizzBuzz, a famous technical interview question that is intended to weed out potential candidates. That question is itself derived from Fizz Buzz, a popular children's game for teaching division. - https://en.wikipedia.org/wiki/Fizz_buzz

--- a/raindrops/Raindrops.fs
+++ b/raindrops/Raindrops.fs
@@ -1,0 +1,10 @@
+module Raindrops
+
+let convert (number: int): string =
+    [ if number % 3 = 0 then "Pling" else ""
+      if number % 5 = 0 then "Plang" else ""
+      if number % 7 = 0 then "Plong" else "" ]
+    |> String.concat ""
+    |> function
+    | "" -> string number
+    | sounds -> sounds

--- a/raindrops/Raindrops.fsproj
+++ b/raindrops/Raindrops.fsproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Raindrops.fs" />
+    <Compile Include="RaindropsTests.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="FsUnit.xUnit" Version="4.0.4" />
+  </ItemGroup>
+
+</Project>

--- a/raindrops/RaindropsTests.fs
+++ b/raindrops/RaindropsTests.fs
@@ -1,0 +1,79 @@
+module RaindropsTests
+
+open FsUnit.Xunit
+open Xunit
+
+open Raindrops
+
+[<Fact>]
+let ``The sound for 1 is 1`` () =
+    convert 1 |> should equal "1"
+
+[<Fact>]
+let ``The sound for 3 is Pling`` () =
+    convert 3 |> should equal "Pling"
+
+[<Fact>]
+let ``The sound for 5 is Plang`` () =
+    convert 5 |> should equal "Plang"
+
+[<Fact>]
+let ``The sound for 7 is Plong`` () =
+    convert 7 |> should equal "Plong"
+
+[<Fact>]
+let ``The sound for 6 is Pling as it has a factor 3`` () =
+    convert 6 |> should equal "Pling"
+
+[<Fact>]
+let ``2 to the power 3 does not make a raindrop sound as 3 is the exponent not the base`` () =
+    convert 8 |> should equal "8"
+
+[<Fact>]
+let ``The sound for 9 is Pling as it has a factor 3`` () =
+    convert 9 |> should equal "Pling"
+
+[<Fact>]
+let ``The sound for 10 is Plang as it has a factor 5`` () =
+    convert 10 |> should equal "Plang"
+
+[<Fact>]
+let ``The sound for 14 is Plong as it has a factor of 7`` () =
+    convert 14 |> should equal "Plong"
+
+[<Fact>]
+let ``The sound for 15 is PlingPlang as it has factors 3 and 5`` () =
+    convert 15 |> should equal "PlingPlang"
+
+[<Fact>]
+let ``The sound for 21 is PlingPlong as it has factors 3 and 7`` () =
+    convert 21 |> should equal "PlingPlong"
+
+[<Fact>]
+let ``The sound for 25 is Plang as it has a factor 5`` () =
+    convert 25 |> should equal "Plang"
+
+[<Fact>]
+let ``The sound for 27 is Pling as it has a factor 3`` () =
+    convert 27 |> should equal "Pling"
+
+[<Fact>]
+let ``The sound for 35 is PlangPlong as it has factors 5 and 7`` () =
+    convert 35 |> should equal "PlangPlong"
+
+[<Fact>]
+let ``The sound for 49 is Plong as it has a factor 7`` () =
+    convert 49 |> should equal "Plong"
+
+[<Fact>]
+let ``The sound for 52 is 52`` () =
+    convert 52 |> should equal "52"
+
+[<Fact>]
+let ``The sound for 105 is PlingPlangPlong as it has factors 3, 5 and 7`` () =
+    convert 105 |> should equal "PlingPlangPlong"
+
+[<Fact>]
+let ``The sound for 3125 is Plang as it has a factor 5`` () =
+    convert 3125 |> should equal "Plang"
+


### PR DESCRIPTION
Implemented the Raindrops exercise from Exercism's F# Track. This includes the creation of a README with task instructions, a test file, a solution file, and a project file detailing the set-up. The solution entails a function that converts numbers into corresponding raindrop sounds based on their divisibility by 3, 5, and 7.

@coderabbitai ignore