### PR TITLE
Add acronym tests and related functions

### DIFF
--- a/acronym/Acronym.fs
+++ b/acronym/Acronym.fs
@@ -1,0 +1,8 @@
+module Acronym
+
+open System
+
+let abbreviate (phrase: string) =
+    phrase.Split([| ' '; '-'; '_' |], StringSplitOptions.RemoveEmptyEntries)
+    |> Array.map (Seq.head >> Char.ToUpper)
+    |> String

--- a/acronym/Acronym.fsproj
+++ b/acronym/Acronym.fsproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Acronym.fs" />
+    <Compile Include="AcronymTests.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="FsUnit.xUnit" Version="4.0.4" />
+  </ItemGroup>
+
+</Project>

--- a/acronym/AcronymTests.fs
+++ b/acronym/AcronymTests.fs
@@ -1,0 +1,43 @@
+module AcronymTests
+
+open FsUnit.Xunit
+open Xunit
+
+open Acronym
+
+[<Fact>]
+let ``Basic`` () =
+    abbreviate "Portable Network Graphics" |> should equal "PNG"
+
+[<Fact>]
+let ``Lowercase words`` () =
+    abbreviate "Ruby on Rails" |> should equal "ROR"
+
+[<Fact>]
+let ``Punctuation`` () =
+    abbreviate "First In, First Out" |> should equal "FIFO"
+
+[<Fact>]
+let ``All caps word`` () =
+    abbreviate "GNU Image Manipulation Program" |> should equal "GIMP"
+
+[<Fact>]
+let ``Punctuation without whitespace`` () =
+    abbreviate "Complementary metal-oxide semiconductor" |> should equal "CMOS"
+
+[<Fact>]
+let ``Very long abbreviation`` () =
+    abbreviate "Rolling On The Floor Laughing So Hard That My Dogs Came Over And Licked Me" |> should equal "ROTFLSHTMDCOALM"
+
+[<Fact>]
+let ``Consecutive delimiters`` () =
+    abbreviate "Something - I made up from thin air" |> should equal "SIMUFTA"
+
+[<Fact>]
+let ``Apostrophes`` () =
+    abbreviate "Halley's Comet" |> should equal "HC"
+
+[<Fact>]
+let ``Underscore emphasis`` () =
+    abbreviate "The Road _Not_ Taken" |> should equal "TRNT"
+

--- a/acronym/README.md
+++ b/acronym/README.md
@@ -1,0 +1,42 @@
+# Acronym
+
+Welcome to Acronym on Exercism's F# Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+Convert a phrase to its acronym.
+
+Techies love their TLA (Three Letter Acronyms)!
+
+Help generate some jargon by writing a program that converts a long name like Portable Network Graphics to its acronym (PNG).
+
+Punctuation is handled as follows: hyphens are word separators (like whitespace); all other punctuation can be removed from the input.
+
+For example:
+
+| Input                     | Output |
+| ------------------------- | ------ |
+| As Soon As Possible       | ASAP   |
+| Liquid-crystal display    | LCD    |
+| Thank George It's Friday! | TGIF   |
+
+## Source
+
+### Created by
+
+- @ErikSchierboom
+
+### Contributed to by
+
+- @balazsbotond
+- @jrr
+- @lestephane
+- @robkeim
+- @valentin-p
+- @vrnithinkumar
+- @wolf99
+
+### Based on
+
+Julien Vanier - https://github.com/monkbroc


### PR DESCRIPTION
This commit adds a group of tests in 'AcronymTests.fs' for string abbreviating functionality and updates 'Acronym.fs' with the actual abbreviating function. It also includes changes to the project file 'Acronym.fsproj' to handle these new files and updates the README.md with instructions and descriptions.

@coderabbitai ignore