### PR TITLE
Added 'Accumulate' exercise and tests

### DIFF
--- a/accumulate/Accumulate.fs
+++ b/accumulate/Accumulate.fs
@@ -1,0 +1,3 @@
+module Accumulate
+
+let accumulate (func: 'a -> 'b) (input: 'a list): 'b list = input |> List.map func

--- a/accumulate/Accumulate.fsproj
+++ b/accumulate/Accumulate.fsproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Accumulate.fs" />
+    <Compile Include="AccumulateTests.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="FsUnit.xUnit" Version="4.0.4" />
+  </ItemGroup>
+
+</Project>

--- a/accumulate/AccumulateTests.fs
+++ b/accumulate/AccumulateTests.fs
@@ -1,0 +1,42 @@
+// This file was created manually and its version is 2.0.0
+
+module AccumulateTest
+
+open System
+open Xunit
+open FsUnit.Xunit
+open Accumulate
+
+let reverse (str:string) = new string(str.ToCharArray() |> Array.rev)
+
+[<Fact>]
+let ``Empty accumulation produces empty accumulation`` () =
+    accumulate (fun x -> x + 1) List.empty |> should be Empty
+
+[<Fact>]
+let ``Identity accumulation returns unmodified list`` () =
+    accumulate id [1; 2; 3] |> should equal [1; 2; 3]
+
+[<Fact>]
+let ``Accumulate squares`` () =
+    accumulate (fun x -> x * x) [1; 2; 3] |> should equal [1; 4; 9]
+
+[<Fact>]
+let ``Accumulate upcases`` () =
+    accumulate (fun (x:string) -> x.ToUpper()) ["hello"; "world"]
+    |> should equal ["HELLO"; "WORLD"]
+
+[<Fact>]
+let ``Accumulate reversed strings`` () =
+    accumulate reverse (List.ofArray ("the quick brown fox etc".Split(' ')))
+    |> should equal (List.ofArray("eht kciuq nworb xof cte".Split(' ')))
+
+[<Fact>]
+let ``Accumulate within accumulate`` () =
+    accumulate (fun (x:string) -> String.concat " " (accumulate (fun y -> x + y) ["1"; "2"; "3"])) ["a"; "b"; "c"]
+    |> should equal ["a1 a2 a3"; "b1 b2 b3"; "c1 c2 c3"]
+
+[<Fact>]
+let ``Accumulate large data set without stack overflow`` () =
+    accumulate id [1..100000]
+    |> should equal [1..100000]

--- a/accumulate/README.md
+++ b/accumulate/README.md
@@ -1,0 +1,53 @@
+# Accumulate
+
+Welcome to Accumulate on Exercism's F# Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+Implement the `accumulate` operation, which, given a collection and an operation to perform on each element of the collection, returns a new collection containing the result of applying that operation to each element of the input collection.
+
+Given the collection of numbers:
+
+- 1, 2, 3, 4, 5
+
+And the operation:
+
+- square a number (`x => x * x`)
+
+Your code should be able to produce the collection of squares:
+
+- 1, 4, 9, 16, 25
+
+Check out the test suite to see the expected function signature.
+
+## Restrictions
+
+Keep your hands off that collect/map/fmap/whatchamacallit functionality provided by your standard library!
+Solve this one yourself using other basic tools instead.
+
+For this exercise the following F# feature comes in handy:
+
+- [Tail recursion](https://blogs.msdn.microsoft.com/fsharpteam/2011/07/08/tail-calls-in-f/) Prevent stack overflows with large input by using tail recursion. While there are no test cases checking explicitly for this, using tail recursion leads to a more performant solution. Another good resource on tail recursion is [this blog post](http://blog.ploeh.dk/2015/12/22/tail-recurse/).
+- [Type inference](https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/generics/#implicitly-generic-constructs) The F# compiler can automatically infer types, which means you often don't have to add any types at all. For more information on how this works and its advantages, see [this page](https://fsharpforfunandprofit.com/posts/type-inference/).
+
+## Source
+
+### Created by
+
+- @ErikSchierboom
+
+### Contributed to by
+
+- @connorads
+- @jrr
+- @kytrinyx
+- @lestephane
+- @mpriestman
+- @robkeim
+- @valentin-p
+- @wolf99
+
+### Based on
+
+Conversation with James Edward Gray II - http://graysoftinc.com/


### PR DESCRIPTION
Implemented the Accumulate operation in the F# track. The operation performs an operation on each element of an input collection and returns a new collection with the applied operations results. The solution also includes associated unit tests. Added a README for the exercise providing the guidelines and expectations.

@coderabbitai ignore