### PR TITLE
Add Hamming distance functionality and corresponding tests

### DIFF
--- a/hamming/Hamming.fs
+++ b/hamming/Hamming.fs
@@ -1,0 +1,10 @@
+module Hamming
+
+let distance (strand1: string) (strand2: string): int option =
+    if strand1.Length <> strand2.Length then
+        None
+    else
+        Seq.zip strand1 strand2
+        |> Seq.filter (fun x -> fst x <> snd x)
+        |> Seq.length
+        |> Some

--- a/hamming/Hamming.fsproj
+++ b/hamming/Hamming.fsproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Hamming.fs" />
+    <Compile Include="HammingTests.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="FsUnit.xUnit" Version="4.0.4" />
+  </ItemGroup>
+
+</Project>

--- a/hamming/HammingTests.fs
+++ b/hamming/HammingTests.fs
@@ -1,0 +1,43 @@
+module HammingTests
+
+open FsUnit.Xunit
+open Xunit
+
+open Hamming
+
+[<Fact>]
+let ``Empty strands`` () =
+    distance "" "" |> should equal (Some 0)
+
+[<Fact>]
+let ``Single letter identical strands`` () =
+    distance "A" "A" |> should equal (Some 0)
+
+[<Fact>]
+let ``Single letter different strands`` () =
+    distance "G" "T" |> should equal (Some 1)
+
+[<Fact>]
+let ``Long identical strands`` () =
+    distance "GGACTGAAATCTG" "GGACTGAAATCTG" |> should equal (Some 0)
+
+[<Fact>]
+let ``Long different strands`` () =
+    distance "GGACGGATTCTG" "AGGACGGATTCT" |> should equal (Some 9)
+
+[<Fact>]
+let ``Disallow first strand longer`` () =
+    distance "AATG" "AAA" |> should equal None
+
+[<Fact>]
+let ``Disallow second strand longer`` () =
+    distance "ATA" "AGTG" |> should equal None
+
+[<Fact>]
+let ``Disallow empty first strand`` () =
+    distance "" "G" |> should equal None
+
+[<Fact>]
+let ``Disallow empty second strand`` () =
+    distance "G" "" |> should equal None
+

--- a/hamming/README.md
+++ b/hamming/README.md
@@ -1,0 +1,52 @@
+# Hamming
+
+Welcome to Hamming on Exercism's F# Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+Calculate the Hamming Distance between two DNA strands.
+
+Your body is made up of cells that contain DNA.
+Those cells regularly wear out and need replacing, which they achieve by dividing into daughter cells.
+In fact, the average human body experiences about 10 quadrillion cell divisions in a lifetime!
+
+When cells divide, their DNA replicates too.
+Sometimes during this process mistakes happen and single pieces of DNA get encoded with the incorrect information.
+If we compare two strands of DNA and count the differences between them we can see how many mistakes occurred.
+This is known as the "Hamming Distance".
+
+We read DNA using the letters C,A,G and T.
+Two strands might look like this:
+
+    GAGCCTACTAACGGGAT
+    CATCGTAATGACGGCCT
+    ^ ^ ^  ^ ^    ^^
+
+They have 7 differences, and therefore the Hamming Distance is 7.
+
+The Hamming Distance is useful for lots of things in science, not just biology, so it's a nice phrase to be familiar with :)
+
+## Implementation notes
+
+The Hamming distance is only defined for sequences of equal length, so an attempt to calculate it between sequences of different lengths should not work.
+
+## Source
+
+### Created by
+
+- @ErikSchierboom
+
+### Contributed to by
+
+- @jrr
+- @kytrinyx
+- @lestephane
+- @robkeim
+- @valentin-p
+- @wolf99
+- @aage
+
+### Based on
+
+The Calculating Point Mutations problem at Rosalind - https://rosalind.info/problems/hamm/


### PR DESCRIPTION
This commit introduces a new module, Hamming, responsible for calculating the Hamming distance between two DNA strands. Along with this, a suite of tests has been added to validate this functionality. The README file has also been updated with instructions and implementation notes.

@coderabbitai ignore