### PR TITLE
Add CircularBuffer exercise with tests

### DIFF
--- a/circular-buffer/CircularBuffer.fs
+++ b/circular-buffer/CircularBuffer.fs
@@ -1,0 +1,41 @@
+module CircularBuffer
+
+type CircularBuffer =
+    { buffer: int array
+      head: int ref
+      size: int ref }
+
+type CircularBuffer with
+    member this.write data =
+        this.buffer[ this.head.Value ] <- data
+        this.head.Value <- (this.head.Value + 1) % this.buffer.Length
+        this.size.Value <- min (this.size.Value + 1) this.buffer.Length
+        this
+        
+    member this.read() =
+        let index = (this.buffer.Length + this.head.Value - this.size.Value) % this.buffer.Length
+        this.size.Value <- this.size.Value - 1
+        this.buffer[index]
+
+let mkCircularBuffer size =
+    { buffer = Array.create size 0
+      head = ref 0
+      size = ref 0 }
+
+let clear buffer =
+    buffer.size.Value <- 0
+    buffer
+
+let write value buffer =
+    if buffer.size.Value = buffer.buffer.Length
+    then failwith "You need to implement this function."
+    else buffer.write value
+
+let forceWrite value (buffer: CircularBuffer) = buffer.write value
+
+let read buffer =
+    if buffer.size.Value = 0 then
+        failwith "Tried to read from empty buffer"
+        0, buffer
+    else 
+        buffer.read(), buffer

--- a/circular-buffer/CircularBuffer.fsproj
+++ b/circular-buffer/CircularBuffer.fsproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="CircularBuffer.fs" />
+    <Compile Include="CircularBufferTests.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="FsUnit.xUnit" Version="4.0.4" />
+  </ItemGroup>
+
+</Project>

--- a/circular-buffer/CircularBufferTests.fs
+++ b/circular-buffer/CircularBufferTests.fs
@@ -1,0 +1,143 @@
+module CircularBufferTests
+
+open FsUnit.Xunit
+open Xunit
+open System
+
+open CircularBuffer
+
+[<Fact>]
+let ``Reading empty buffer should fail`` () =
+    let buffer1 = mkCircularBuffer 1
+    (fun () -> read buffer1 |> ignore) |> should throw typeof<Exception>
+
+[<Fact>]
+let ``Can read an item just written`` () =
+    let buffer1 = mkCircularBuffer 1
+    let buffer2 = write 1 buffer1
+    let (val3, _) = read buffer2
+    val3 |> should equal 1
+
+[<Fact>]
+let ``Each item may only be read once`` () =
+    let buffer1 = mkCircularBuffer 1
+    let buffer2 = write 1 buffer1
+    let (val3, buffer3) = read buffer2
+    val3 |> should equal 1
+    (fun () -> read buffer3 |> ignore) |> should throw typeof<Exception>
+
+[<Fact>]
+let ``Items are read in the order they are written`` () =
+    let buffer1 = mkCircularBuffer 2
+    let buffer2 = write 1 buffer1
+    let buffer3 = write 2 buffer2
+    let (val4, buffer4) = read buffer3
+    val4 |> should equal 1
+    let (val5, _) = read buffer4
+    val5 |> should equal 2
+
+[<Fact>]
+let ``Full buffer can't be written to`` () =
+    let buffer1 = mkCircularBuffer 1
+    let buffer2 = write 1 buffer1
+    (fun () -> write 2 buffer2 |> ignore) |> should throw typeof<Exception>
+
+[<Fact>]
+let ``A read frees up capacity for another write`` () =
+    let buffer1 = mkCircularBuffer 1
+    let buffer2 = write 1 buffer1
+    let (val3, buffer3) = read buffer2
+    val3 |> should equal 1
+    let buffer4 = write 2 buffer3
+    let (val5, _) = read buffer4
+    val5 |> should equal 2
+
+[<Fact>]
+let ``Read position is maintained even across multiple writes`` () =
+    let buffer1 = mkCircularBuffer 3
+    let buffer2 = write 1 buffer1
+    let buffer3 = write 2 buffer2
+    let (val4, buffer4) = read buffer3
+    val4 |> should equal 1
+    let buffer5 = write 3 buffer4
+    let (val6, buffer6) = read buffer5
+    val6 |> should equal 2
+    let (val7, _) = read buffer6
+    val7 |> should equal 3
+
+[<Fact>]
+let ``Items cleared out of buffer can't be read`` () =
+    let buffer1 = mkCircularBuffer 1
+    let buffer2 = write 1 buffer1
+    let buffer3 = clear buffer2
+    (fun () -> read buffer3 |> ignore) |> should throw typeof<Exception>
+
+[<Fact>]
+let ``Clear frees up capacity for another write`` () =
+    let buffer1 = mkCircularBuffer 1
+    let buffer2 = write 1 buffer1
+    let buffer3 = clear buffer2
+    let buffer4 = write 2 buffer3
+    let (val5, _) = read buffer4
+    val5 |> should equal 2
+
+[<Fact>]
+let ``Clear does nothing on empty buffer`` () =
+    let buffer1 = mkCircularBuffer 1
+    let buffer2 = clear buffer1
+    let buffer3 = write 1 buffer2
+    let (val4, _) = read buffer3
+    val4 |> should equal 1
+
+[<Fact>]
+let ``Overwrite acts like write on non-full buffer`` () =
+    let buffer1 = mkCircularBuffer 2
+    let buffer2 = write 1 buffer1
+    let buffer3 = forceWrite 2 buffer2
+    let (val4, buffer4) = read buffer3
+    val4 |> should equal 1
+    let (val5, _) = read buffer4
+    val5 |> should equal 2
+
+[<Fact>]
+let ``Overwrite replaces the oldest item on full buffer`` () =
+    let buffer1 = mkCircularBuffer 2
+    let buffer2 = write 1 buffer1
+    let buffer3 = write 2 buffer2
+    let buffer4 = forceWrite 3 buffer3
+    let (val5, buffer5) = read buffer4
+    val5 |> should equal 2
+    let (val6, _) = read buffer5
+    val6 |> should equal 3
+
+[<Fact>]
+let ``Overwrite replaces the oldest item remaining in buffer following a read`` () =
+    let buffer1 = mkCircularBuffer 3
+    let buffer2 = write 1 buffer1
+    let buffer3 = write 2 buffer2
+    let buffer4 = write 3 buffer3
+    let (val5, buffer5) = read buffer4
+    val5 |> should equal 1
+    let buffer6 = write 4 buffer5
+    let buffer7 = forceWrite 5 buffer6
+    let (val8, buffer8) = read buffer7
+    val8 |> should equal 3
+    let (val9, buffer9) = read buffer8
+    val9 |> should equal 4
+    let (val10, _) = read buffer9
+    val10 |> should equal 5
+
+[<Fact>]
+let ``Initial clear does not affect wrapping around`` () =
+    let buffer1 = mkCircularBuffer 2
+    let buffer2 = clear buffer1
+    let buffer3 = write 1 buffer2
+    let buffer4 = write 2 buffer3
+    let buffer5 = forceWrite 3 buffer4
+    let buffer6 = forceWrite 4 buffer5
+    let (val7, buffer7) = read buffer6
+    val7 |> should equal 3
+    let (val8, buffer8) = read buffer7
+    val8 |> should equal 4
+    (fun () -> read buffer8 |> ignore) |> should throw typeof<Exception>
+

--- a/circular-buffer/README.md
+++ b/circular-buffer/README.md
@@ -1,0 +1,81 @@
+# Circular Buffer
+
+Welcome to Circular Buffer on Exercism's F# Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+A circular buffer, cyclic buffer or ring buffer is a data structure that uses a single, fixed-size buffer as if it were connected end-to-end.
+
+A circular buffer first starts empty and of some predefined length.
+For example, this is a 7-element buffer:
+
+```text
+[ ][ ][ ][ ][ ][ ][ ]
+```
+
+Assume that a 1 is written into the middle of the buffer (exact starting location does not matter in a circular buffer):
+
+```text
+[ ][ ][ ][1][ ][ ][ ]
+```
+
+Then assume that two more elements are added — 2 & 3 — which get appended after the 1:
+
+```text
+[ ][ ][ ][1][2][3][ ]
+```
+
+If two elements are then removed from the buffer, the oldest values inside the buffer are removed.
+The two elements removed, in this case, are 1 & 2, leaving the buffer with just a 3:
+
+```text
+[ ][ ][ ][ ][ ][3][ ]
+```
+
+If the buffer has 7 elements then it is completely full:
+
+```text
+[5][6][7][8][9][3][4]
+```
+
+When the buffer is full an error will be raised, alerting the client that further writes are blocked until a slot becomes free.
+
+When the buffer is full, the client can opt to overwrite the oldest data with a forced write.
+In this case, two more elements — A & B — are added and they overwrite the 3 & 4:
+
+```text
+[5][6][7][8][9][A][B]
+```
+
+3 & 4 have been replaced by A & B making 5 now the oldest data in the buffer.
+Finally, if two elements are removed then what would be returned is 5 & 6 yielding the buffer:
+
+```text
+[ ][ ][7][8][9][A][B]
+```
+
+Because there is space available, if the client again uses overwrite to store C & D then the space where 5 & 6 were stored previously will be used not the location of 7 & 8.
+7 is still the oldest element and the buffer is once again full.
+
+```text
+[C][D][7][8][9][A][B]
+```
+
+## Source
+
+### Created by
+
+- @ErikSchierboom
+
+### Contributed to by
+
+- @jrr
+- @lestephane
+- @robkeim
+- @valentin-p
+- @wolf99
+
+### Based on
+
+Wikipedia - https://en.wikipedia.org/wiki/Circular_buffer

--- a/collatz-conjecture/CollatzConjecture.fs
+++ b/collatz-conjecture/CollatzConjecture.fs
@@ -1,21 +1,19 @@
 module CollatzConjecture
+
 let (|Even|Odd|) number =
     match number % 2 with
     | 0 -> Even
     | _ -> Odd
-    
+
 let steps (number: int): int option =
-    
     let next number =
         match number with
         | Even -> number / 2
         | Odd -> 3 * number + 1
-    
-    let rec countStepsFor number : int =
-        if number < 2
-        then 0
-        else 1 + countStepsFor (next number)
-    
-    if number < 1
-    then None
-    else Some <| countStepsFor number
+
+    let rec countStepsFor number: int =
+        match number with
+        | 1 -> 0
+        | _ -> 1 + countStepsFor (next number)
+
+    if number < 1 then None else Some <| countStepsFor number

--- a/raindrops/Raindrops.fs
+++ b/raindrops/Raindrops.fs
@@ -1,9 +1,10 @@
 module Raindrops
 
 let convert (number: int): string =
-    [ if number % 3 = 0 then Some "Pling" else None
-      if number % 5 = 0 then Some "Plang" else None
-      if number % 7 = 0 then Some "Plong" else None ]
+    let sound (divider, word) =
+        if number % divider = 0 then Some word else None
+    [ 3, "Pling"; 5, "Plang"; 7, "Plong" ]
+    |> List.map sound
     |> List.choose id
     |> function
     | [] -> string number


### PR DESCRIPTION
Created a new exercise, CircularBuffer, with corresponding tests. In this update, 'CircularBuffer.fs', 'CircularBufferTests.fs', 'CircularBuffer.fsproj', and 'README.md' files were created. Also included are minor changes to 'CollatzConjecture.fs' and 'Raindrops.fs'. The exercise deals with testing the functionality of a circular buffer data structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a `CircularBuffer` module with capabilities to write, read, and manage circular buffer data structures.
  - Enhanced the `CollatzConjecture` module with simplified recursive logic for calculating steps.
  - Refined the `Raindrops` module to convert numbers into raindrop sounds using a streamlined method.

- **Refactor**
  - Improved the `steps` function in `CollatzConjecture` for better clarity and performance.
  - Overhauled the `convert` function in `Raindrops` to use a more efficient mapping approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->