### PR TITLE
Refactor phone number validation

### DIFF
--- a/phone-number/PhoneNumber.fs
+++ b/phone-number/PhoneNumber.fs
@@ -2,33 +2,40 @@ module PhoneNumber
 
 open System
 
-let validateNumber (number:string) =
-    match number with
-    | _ when number[0] = '0' -> Error "area code cannot start with zero"
-    | _ when number[0] = '1' -> Error "area code cannot start with one"
-    | _ when number[3] = '0' -> Error "exchange code cannot start with zero"
-    | _ when number[3] = '1' -> Error "exchange code cannot start with one"
-    | _ ->  number |> uint64 |> Ok
+type private Code =
+    | Area = 0
+    | Exchange = 3
     
-let validateLength (digits:string) =
+let private validateCode code (number:string) =
+    let codeName = code.ToString().ToLower()
+    match number[int code] with
+    | '0' -> Error $"{codeName} code cannot start with zero"
+    | '1' -> Error $"{codeName} code cannot start with one"
+    | _ -> Ok number
+   
+let private validateLength (digits:string) =
     match digits.Length with
     | length when length > 11 -> Error "more than 11 digits"
     | 11 when digits[0] <> '1' -> Error "11 digits must start with 1"
-    | 10 -> Ok digits
     | 11 -> Ok digits[1..]
+    | 10 -> Ok digits
     | _ -> Error "incorrect number of digits"
         
-let keepDigits input = input |> Seq.filter Char.IsDigit |> String.Concat
+let private keepDigits input = input |> Seq.filter Char.IsDigit |> String.Concat
 
-let isPunctuation (symbol:char) = ",:;".Contains symbol
+let private isPunctuation (symbol:char) =
+      not <| ".()-".Contains symbol && (Char.IsPunctuation symbol)
     
-let validate input =
+let private validateSymbols input =
     match input with
     | _ when Seq.exists Char.IsLetter input -> Error "letters not permitted"
     | _ when Seq.exists isPunctuation input -> Error "punctuations not permitted"
     | _ -> keepDigits input |> Ok 
     
 let clean input =
-    validate input
+    input
+    |> validateSymbols 
     |> Result.bind validateLength
-    |> Result.bind validateNumber
+    |> Result.bind (validateCode Code.Area)
+    |> Result.bind (validateCode Code.Exchange)
+    |> Result.map UInt64.Parse

--- a/strain/README.md
+++ b/strain/README.md
@@ -1,0 +1,52 @@
+# Strain
+
+Welcome to Strain on Exercism's F# Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+Implement the `keep` and `discard` operation on collections.
+Given a collection and a predicate on the collection's elements, `keep` returns a new collection containing those elements where the predicate is true, while `discard` returns a new collection containing those elements where the predicate is false.
+
+For example, given the collection of numbers:
+
+- 1, 2, 3, 4, 5
+
+And the predicate:
+
+- is the number even?
+
+Then your keep operation should produce:
+
+- 2, 4
+
+While your discard operation should produce:
+
+- 1, 3, 5
+
+Note that the union of keep and discard is all the elements.
+
+The functions may be called `keep` and `discard`, or they may need different names in order to not clash with existing functions or concepts in your language.
+
+## Restrictions
+
+Keep your hands off that filter/reject/whatchamacallit functionality provided by your standard library!
+Solve this one yourself using other basic tools instead.
+
+## Source
+
+### Created by
+
+- @ErikSchierboom
+
+### Contributed to by
+
+- @jrr
+- @lestephane
+- @robkeim
+- @valentin-p
+- @wolf99
+
+### Based on
+
+Conversation with James Edward Gray II - http://graysoftinc.com/

--- a/strain/Strain.fs
+++ b/strain/Strain.fs
@@ -1,0 +1,7 @@
+module Seq
+
+let keep pred xs =
+    xs |> Seq.filter pred
+
+let discard pred xs =
+    xs |> Seq.filter (pred >> not)

--- a/strain/Strain.fsproj
+++ b/strain/Strain.fsproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Strain.fs" />
+    <Compile Include="StrainTests.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="FsUnit.xUnit" Version="4.0.4" />
+  </ItemGroup>
+
+</Project>

--- a/strain/StrainTests.fs
+++ b/strain/StrainTests.fs
@@ -1,0 +1,77 @@
+// This file was created manually and its version is 1.0.0.
+
+module StrainTest
+
+open System.Collections.Specialized
+open Xunit
+open FsUnit.Xunit
+
+[<Fact>]
+let ``Empty keep`` () =
+    [] |> Seq.keep (fun x -> x < 10) |> should be Empty
+
+[<Fact>]  
+let ``Keep everything`` () =
+    set [1; 2; 3] |> Seq.keep (fun x -> x < 10) |> Seq.toList |> should equal <| [1; 2; 3]
+
+[<Fact>] 
+let ``Keep first and last`` () =
+    [|1; 2; 3|] |> Seq.keep (fun x -> x % 2 <> 0) |> Seq.toList |> should equal [1; 3]
+
+[<Fact>]
+let ``Keep neither first nor last`` () =
+    [1; 2; 3; 4; 5] |> Seq.keep (fun x -> x % 2 = 0) |> Seq.toList |> should equal [2; 4]
+
+[<Fact>]
+let ``Keep strings`` () =
+    let words = "apple zebra banana zombies cherimoya zelot".Split(' ');
+    words |> Seq.keep (fun (x:string) -> x.StartsWith("z")) |> Seq.toList |> should equal <| List.ofArray("zebra zombies zelot".Split(' '))
+
+[<Fact>]
+let ``Keep arrays`` () =
+    let actual = [|
+                    [|1; 2; 3|];
+                    [|5; 5; 5|];
+                    [|5; 1; 2|];
+                    [|2; 1; 2|];
+                    [|1; 5; 2|];
+                    [|2; 2; 1|];
+                    [|1; 2; 5|]
+                    |]
+    let expected = [ [|5; 5; 5|]; [|5; 1; 2|]; [|1; 5; 2|]; [|1; 2; 5|] ]
+    actual |> Seq.keep (Array.exists ((=) 5)) |> Seq.toList |> should equal expected
+
+[<Fact>]
+let ``Empty discard`` () =
+    [] |> Seq.discard (fun x -> x < 10) |> should be Empty
+
+[<Fact>]
+let ``Discard nothing`` () =
+    set [1; 2; 3] |> Seq.discard (fun x -> x > 10) |> Seq.toList |> should equal <| [1; 2; 3]
+
+[<Fact>]
+let ``Discard first and last`` () =
+    [|1; 2; 3|] |> Seq.discard (fun x -> x % 2 <> 0) |> Seq.toList |> should equal [2]
+
+[<Fact>]
+let ``Discard neither first nor last`` () =
+    [1; 2; 3; 4; 5] |> Seq.discard (fun x -> x % 2 = 0) |> Seq.toList |> should equal [1; 3; 5]
+
+[<Fact>]
+let ``Discard strings`` () =
+    let words = "apple zebra banana zombies cherimoya zelot".Split(' ')
+    words |> Seq.discard (fun (x:string) -> x.StartsWith("z")) |> Seq.toList |> should equal <| List.ofArray("apple banana cherimoya".Split(' '))
+
+[<Fact>]
+let ``Discard arrays`` () =
+    let actual = [|
+                    [|1; 2; 3|];
+                    [|5; 5; 5|];
+                    [|5; 1; 2|];
+                    [|2; 1; 2|];
+                    [|1; 5; 2|];
+                    [|2; 2; 1|];
+                    [|1; 2; 5|]
+                    |]
+    let expected = [ [|1; 2; 3|]; [|2; 1; 2|]; [|2; 2; 1|] ]
+    actual |> Seq.discard (Array.exists ((=) 5)) |> Seq.toList |> should equal expected


### PR DESCRIPTION
The phone number validation logic has been overhauled. A private Code type has been introduced to improve readability and maintainability. 'validateNumber' was split into 'validateCode' being more generic and reusable. The 'clean' function now explicitly validates symbols before validating length, area, and exchange codes.