### PR TITLE
Refactor String.concat in Raindrops & optimize KindergartenGarden

### DIFF
--- a/kindergarten-garden/KindergartenGarden.fs
+++ b/kindergarten-garden/KindergartenGarden.fs
@@ -6,20 +6,19 @@ type Plant =
     | Radishes
     | Violets
 
-let toPlant symbol =
-    match symbol with
+let private toPlant =
+    function
     | 'G' -> Grass
     | 'C' -> Clover
     | 'R' -> Radishes
     | 'V' -> Violets
-    | _ -> failwith $"Unknown symbol '{symbol}'"
+    | symbol -> failwith $"Unknown symbol '{symbol}'"
     
 let plants (diagram: string) (student:string) =
-    let startIndex = 2 * int (student[ 0 ] - 'A')
+    let startIndex = 2 * int (student[0] - 'A')
     
     diagram.Split('\n')
-    |> Seq.map _.Substring(startIndex, 2)
-    |> String.concat ""
+    |> Seq.collect _.Substring(startIndex, 2)
     |> Seq.map toPlant
     |> Seq.toList
 

--- a/raindrops/Raindrops.fs
+++ b/raindrops/Raindrops.fs
@@ -8,4 +8,4 @@ let convert (number: int): string =
     |> List.choose id
     |> function
     | [] -> string number
-    | sounds -> String.concat "" sounds
+    | sounds -> System.String.Concat sounds


### PR DESCRIPTION
Changed the string concatenation logic in Raindrops.fs to use System.String.Concat. Also optimized the KindergartenGarden.fs by replacing map function with collect for string concatenation, and streamlined 'toPlant' function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal code structure for plant and raindrop functions without altering user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->